### PR TITLE
Sugestões de melhorias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ embeddings.txt
 *.npz
 *.idx
 .ipynb_checkpoints
+.idea

--- a/TP2 - Dojo - Indice.ipynb
+++ b/TP2 - Dojo - Indice.ipynb
@@ -10,9 +10,9 @@
     "\n",
     "- `structure.py`: Possui toda a estrutura do índice;\n",
     "- `index_structure_test.py`: Testa a estrutura do índice;\n",
-    "- `file_index_test.py`: Possui os testes unitários específicos para a indexação das ocorrencias em arquivos da classe `FileIndex`;\n",
-    "- `performance_test.py`: Executa um teste de performance (tempo de execução e memória utilizada) do índice;\n",
-    "- `indexer.py`: Possui as classes para o preprocessamento e preparação para a indexação;\n",
+    "- `file_index_test.py`: Possui os testes unitários específicos para a indexação das ocorrências em arquivos da classe `FileIndex`;\n",
+    "- `performance_test.py`: Executa um teste de desempenho (tempo de execução e memória utilizada) do índice;\n",
+    "- `indexer.py`: Possui as classes para o pré-processamento e preparação para a indexação;\n",
     "- `indexer_test.py`: Realiza o [teste de integração](https://en.wikipedia.org/wiki/Integration_testing) da prática como um todo (inclusive as funções da indexer.py).\n",
     "\n",
     "Na entrega, não esqueça de apresentar a saída de execução de cada atividade desta tarefa."
@@ -36,7 +36,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- `dic_index`:  dicionário em que a chave é o termo indexação (string, gerenciado por esta classe) e, os valores,  podem der de diferentes tipos - dependendo da subclasse;\n",
+    "- `dic_index`: dicionário em que a chave é o termo indexação (string, gerenciado por esta classe) e, os valores, podem der de diferentes tipos - dependendo da subclasse;\n",
     "- `set_documents`: conjunto de ids de documentos existentes."
    ]
   },
@@ -60,21 +60,21 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Atividade 1 - método index da classe Index**: Este método esta quase todo pronto e é reponsável por indexar um termo com sua frequncia e documento no índice, de acordo com uma de suas subclasses. Você deve deve apenas inicializar a variável `int_term_id` apropriadamente - substituindo os `None` correspondente. Caso o termo não exista no índice, deverá obter o próximo term_id. Esse id pode ser sequencial. Caso esse id seja encontrado, a classe Index deverá chamar o método `get_term_id` (implementado pelas subclasses) para obtê-lo pois, dependendo da implementação, haverá uma forma diferente de obtenção. Além disso, você deverá atualizar o atributo `set_documents` apropriadamente. Para testar tanto esta atividade e a seguinte,  você deverá fazer uma das implementações dessa classe - a classe **HashIndex** - na atividade 3. "
+    "**Atividade 1 — método index da classe Index**: Este método esta quase todo pronto e é responsável por indexar um termo com a sua frequncia e documento no índice, de acordo com uma de suas subclasses. Você deve deve apenas inicializar a variável `int_term_id` apropriadamente - substituindo os `None` correspondente. Caso o termo não exista no índice, deverá obter o próximo term_id. Esse id pode ser sequencial. Caso esse id seja encontrado, a classe Index deverá chamar o método `get_term_id` (implementado pelas subclasses) para obtê-lo pois, dependendo da implementação, haverá uma forma diferente de obtenção. Além disso, você deverá atualizar o atributo `set_documents` apropriadamente. Para testar tanto esta atividade e a seguinte, você deverá fazer uma das implementações dessa classe - a classe **HashIndex** - na atividade 3."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Atividade 2 - atributos calculados da classe Index**: Você deve implementar os atributos calculados `document_count` e `vocabulary` da classe Index. O atributo `document_count` retorna a quantidade de documentos existentes e, `vocabulary` retorna uma lista com o vocabulário completo indexado. "
+    "**Atividade 2 — atributos calculados da classe Index**: Você deve implementar os atributos calculados `document_count` e `vocabulary` da classe Index. O atributo `document_count` retorna a quantidade de documentos existentes e, `vocabulary` retorna uma lista com o vocabulário completo indexado."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Atividade 3 - Implementação da classe HashIndex: ** O HashIndex deverá fazer um índice em memória.\n",
+    "**Atividade 3 — Implementação da classe HashIndex:** O HashIndex deverá fazer um índice em memória.\n",
     "\n",
     "Como exemplo, caso tenhamos três documentos $d_1 = $\"A casa verde é uma casa bonita\", $d_2 = $\"A casa bonita\" e $d_3 =$\"O prédio verde\", caso não haja remoção de _stopwords_ nem acentos, o atributo `dic_index` deverá possuir a seguinte estrutura:"
    ]
@@ -100,14 +100,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Por simplicidade deste indice, perceba que deixamos o `term_id` de forma repetida. Iremos deixar assim, porém poderiamos retirar essa redundancia para reduzir o consumo de memória. Porém, nesta prática, iremos implementar o índice em arquivo que irá ser melhor ainda na questão de consumo de memória ;)"
+    "Por simplicidade deste índice, perceba que deixamos o `term_id` de forma repetida. Iremos deixar assim, porém poderíamos retirar essa redundância para reduzir o consumo de memória. Porém, nesta prática, iremos implementar o índice em arquivo que irá ser melhor ainda na questão de consumo de memória ;)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "O índice é chamado da seguinte forma - esse código só ira funcionar depois que vocẽ terminar esta atividade :):"
+    "O índice é chamado da seguinte forma — esse código só ira funcionar depois que você terminar esta atividade :):"
    ]
   },
   {
@@ -140,18 +140,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A classe `Index` é que irá manter o dicinário com o vocabulário do índice e, dependendo de sua implementação, suas ocorrencias. Iremos fazer duas implementações: a classe `HashIndex`, que faz o indice e suas ocorrencias em memória principal e a classe `FileIndex`, que armazena as ocorrências em arquivo, ambas subclasses de `Index`. O método `finish_indexing` é um método que não está implementado no `Index` e é implementado (opcionalmente) nas suas subclasses caso haja necessidade de fazer algo no final da indexação. Em nosso caso, apenas a classe `FileIndex` irá precisar."
+    "A classe `Index` é que irá manter o dicionário com o vocabulário do índice e, dependendo da sua implementação, as suas ocorrências. Iremos fazer duas implementações: a classe `HashIndex`, que faz o indices e as suas ocorrências em memória principal e a classe `FileIndex`, que armazena as ocorrências em arquivo, ambas subclasses de `Index`. O método `finish_indexing` é um método que não está implementado no `Index` e é implementado (opcionalmente) nas suas subclasses caso haja necessidade de fazer algo no final da indexação. No nosso caso, apenas a classe `FileIndex` irá precisar."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Agora, você deverá implementar a classe HashIndex. Para sua implementação, você deverá completar os seguintes métodos/atributo calculados:\n",
-    "- `create_index_entry`: cria uma nova entrada no índice utilizando, se necessário, o id do termo passado como parâmetro - não será necessário agora. A implementação deste método é **super simples** - apenas substitua o None. Verifique também o método `index` da superclasse para entender melhor o que será retornado;\n",
-    "- `add_index_occur`: Adiciona uma nova ocorrencia na entrada deste índice. Você precisará da entrada do termo atual, o id do documento e frequencia do termo no documento, passado como parâmetro. Atualize substituindo os `None`. Veja também o modo `index` da superclasse para entender melhor como o método funciona.\n",
+    "Agora, você deverá implementar a classe HashIndex. Para a sua implementação, você deverá completar os seguintes métodos/atributos calculados:\n",
+    "- `create_index_entry`: cria uma entrada no índice utilizando, se necessário, o id do termo passado como parâmetro — não será necessário agora. A implementação deste método é **super simples** — apenas substitua o None. Verifique também o método `index` da superclasse para entender melhor o que será retornado;\n",
+    "- `add_index_occur`: Adiciona uma nova ocorrência na entrada deste índice. Você precisará da entrada do termo atual, o id do documento e frequência do termo no documento, passado como parâmetro. Atualize substituindo os `None`. Veja também o modo `index` da superclasse para entender melhor como o método funciona.\n",
     "\n",
-    "Faça os testes baixo para garantir que a atividade atual e as duas anteriores foram implementadas corretamente. Nos primeiros dois testes, você ainda não verá a lista de ocorrências, pois o método para obtê-la será implementado a seguir. "
+    "Faça os testes baixo para garantir que a atividade atual e as duas anteriores foram implementadas corretamente. Nos primeiros dois testes, você ainda não verá a lista de ocorrências, pois o método para a obter será implementado a seguir."
    ]
   },
   {
@@ -183,7 +183,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- `get_occurrence_list`: Retornará a lista de ocorrencias de um determinado termo. Considerando o exemplo apresentado no inicio desta atividade, `index.get_occurrence_list('casa')` retornará a lista `[TermOccurrence(1,2,2), TermOccurrence(2,2,1)]`. Caso um termo não exista, este método deverá retornar uma lista vazia. Logo após, execute o teste abaixo:"
+    "- `get_occurrence_list`: Retornará a lista de ocorrências de um determinado termo. Considerando o exemplo apresentado no início desta atividade, `index.get_occurrence_list('casa')` retornará a lista `[TermOccurrence(1,2,2), TermOccurrence(2,2,1)]`. Caso um termo não exista, este método deverá retornar uma lista vazia. Logo após, execute o teste abaixo:"
    ]
   },
   {
@@ -215,9 +215,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Atividade 4 - métodos de comparação da classe TermOccurrence**: Eventualmente iremos precisar ordenar as ocorrências Por isso, temos que implementar os [comparadores de `__eq__` e `__lt__`](https://docs.python.org/3.7/reference/datamodel.html#object.__lt__) além de usar o _decorator_ [total_ordering](https://docs.python.org/3.7/library/functools.html#functools.total_ordering) - [veja também aqui](https://portingguide.readthedocs.io/en/latest/comparisons.html#rich-comparisons). `__eq__` retorna igual se um objeto é considerado igual ao outro. Considere que uma ocorrencia é igual a outra se o id do termo dela e o id do documento forem iguais. \n",
+    "**Atividade 4 — métodos de comparação da classe TermOccurrence**: Eventualmente iremos precisar ordenar as ocorrências Por isso, temos que implementar os [comparadores de `__eq__` e `__lt__`](https://docs.python.org/3.7/reference/datamodel.html#object.__lt__) além de usar o _decorator_ [total_ordering](https://docs.python.org/3.7/library/functools.html#functools.total_ordering) - [veja também aqui](https://portingguide.readthedocs.io/en/latest/comparisons.html#rich-comparisons). O método `__eq__` retorna igual se um objeto é considerado igual ao outro. Considere que uma ocorrência é igual a outra se o id do termo dela e o id do documento forem iguais.\n",
     "\n",
-    "O comparador `<` é implementado pelo método `__lt__` que retorna verdadeiro sde o objeto corrrente `self` é menor do que o objeto passado como parametro. A ocorrencia deverá ser ordenada primeiramente pelo seu `term_id` e, logo após, pelo `doc_id`. Faça o exemplo abaixo para testar (não esqueça de reiniciar o Kernel quando modificar o código):"
+    "O comparador `<` é implementado pelo método `__lt__` que retorna verdadeiro se o objeto corrente `self` é menor que o objeto passado como parâmetro. A ocorrência deverá ser ordenada primeiramente pelo seu `term_id` e, logo após, pelo `doc_id`. Faça o exemplo abaixo para testar (não esqueça de reiniciar o Kernel quando modificar o código):"
    ]
   },
   {
@@ -237,7 +237,7 @@
     "print(f\"Resultado obtido: {t1 == t5} - esperado: False\")\n",
     "print(f\"Resultado obtido: {t4 == t5} - esperado: True\")\n",
     "print(f\"Resultado obtido: {t1 != t1} - esperado: False\")\n",
-    "print(f\"Resultado obtido: {t1 == None} - esperado: False\")\n",
+    "print(f\"Resultado obtido: {t1 is None} - esperado: False\")\n",
     "print(f\"Resultado obtido: {t1 < t2} - esperado: True\")\n",
     "print(f\"Resultado obtido: {t2 > t3} - esperado: False\")\n",
     "print(f\"Resultado obtido: {t3 < t4} - esperado: True\")\n",
@@ -256,9 +256,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A construção de índice usando apenas memória principal fácil de implementar e eficiente em termos de tempo de execução. Porém, quando precisamos de indexar milhões/bilhões de páginas, é muitas vezes inviável armazenarmos tudo em memória principal. \n",
+    "A construção de índice usando apenas memória principal fácil de implementar e eficiente em tempo de execução. Porém, quando precisamos de indexar milhões/bilhões de páginas, é muitas vezes inviável armazenarmos tudo em memória principal.\n",
     "\n",
-    "Para resolver esse problema, uma solução é mantermos o vocabulário em memória principal e as ocorrências em memória secundária. Assim, teriamos o mesmo atributo `dic_index` na classe `Index`. Porém, cada entrada (termo) referenciará as ocorrencias em arquivo. Utilizando exemplo da atividade 3 neste contexto, no final da indexação, o `dic_index` deve ficar da seguinte forma: "
+    "Para resolver esse problema, uma solução é mantermos o vocabulário em memória principal e as ocorrências em memória secundária. Assim, teríamos o mesmo atributo `dic_index` na classe `Index`. Porém, cada entrada (termo) referenciará as ocorrências em arquivo. Utilizando exemplo da atividade 3 neste contexto, no final da indexação, o `dic_index` deve ficar da seguinte forma:"
    ]
   },
   {
@@ -284,7 +284,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "e as ocorrencias, ordenadas por termo e, logo após, por documento ficariam em um arquivo na seguinte ordem:"
+    "As ocorrências, ordenadas por termo e, logo após, por documento ficariam em um arquivo na seguinte ordem:"
    ]
   },
   {
@@ -311,14 +311,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "em que cada instancia da classe `TermFilePosition` é a especificação da posição inicial de um `term_id` em um arquivo  além de especificar também a quantidade de ocorrencias desse termo. Essa posição inicial e quantidade são definidas nos atributos atributos `term_file_start_pos` e `doc_count_with_term`, respectivamente. A posição inicial está em bytes e, nesse exemplo, foi considerado que cada TermOcurrence possui 10 bytes. Assim, por exemplo, o termo casa (term_id=2) inicia-se na posição 20 e possui duas ocorrências. Com isso, é possível obter todas as ocorrencias de um determinado termo."
+    "Em que cada instância da classe `TermFilePosition` é a especificação da posição inicial de um `term_id` em um arquivo além de especificar também a quantidade de ocorrências desse termo. Essa posição inicial e quantidade são definidas nos atributos `term_file_start_pos` e `doc_count_with_term`, respetivamente. A posição inicial está em ‘bytes’ e, nesse exemplo, foi considerado que cada TermOcurrence possui 10 ‘bytes’. Assim, por exemplo, o termo casa (term_id=2) inicia-se na posição 20 e possui duas ocorrências. Com isso, é possível obter todas as ocorrências de um determinado termo."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Para deixarmos a estrutura dessa forma, temos um dificultador: no arquivo, temos que ordenar as ocorrencias pelo termo, porém, indexamos por documento (veja na atividade 3). Assim, se gravássemos as ocorrências assim que indexarmos, as gravariamos agrupadas por documento."
+    "Para deixarmos a estrutura dessa forma, temos um dificultador: no arquivo, temos que ordenar as ocorrências pelo termo, porém, indexamos por documento (veja na atividade 3). Assim, se gravássemos as ocorrências assim que indexarmos, as gravaríamos agrupadas por documento."
    ]
   },
   {
@@ -332,12 +332,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- Sempre, ao indexar, salvaremos o indice em uma lista (temporária) de ocorrencia de termos `lst_occurrences_tmp`\n",
-    "- Usaremos o método `save_tmp_occurrences` para, assim que a lista estiver com um determinado tamanho, ordená-la pelo termo e salvar de formar ordenada em um novo arquivo de indice com a todas as ocorrencias. Para que seja feito isso, você deverá fazer uma ordenação externa lendo m consideração o índice em arquivo atual e a lista de ocorrencias temporárias. Segue o passo a passo:\n",
-    "    - (1) ordene a lista `lst_occurrences_tmp`. Lembre-se que você implementou os comparadores das instancias TermOccurrence, assim, a ordenação e descobrir o menor valor entre as ocorrencias é uma operação simples;\n",
+    "- Sempre, ao indexar, salvaremos o indices numa lista (temporária) de ocorrência de termos `lst_occurrences_tmp`\n",
+    "- Usaremos o método `save_tmp_occurrences` para, assim que a lista estiver com um determinado tamanho, ordená-la pelo termo e salvar de formar ordenada num novo arquivo de índice com todas as ocorrências. Para ser feito isso, você deverá fazer uma ordenação externa lendo m consideração o índice em arquivo atual e a lista de ocorrências temporárias. Segue o passo a passo:\n",
+    "    - (1) ordene a lista `lst_occurrences_tmp`. Lembre-se que você implementou os comparadores das instâncias TermOccurrence, assim, a ordenação e descobrir o menor valor entre as ocorrências é uma operação simples;\n",
     "    - (2) criar um arquivo novo;\n",
     "    - (3) compare a primeira posição da lista com a primeira posição do arquivo de índice, sempre inserindo a ocorrencia considerada com o menor entre elas no novo arquivo. Lembrando novamente que os comparadores foram implementados e que você possui os métodos `next_from_list` e `next_from_file` - que será implementado na atividade 5(b) para ajudar;\n",
-    "    - (4) esse novo arquivo passará a ser o índice. Exclua o indice antigo e limpe a lista de ocorrencias `lst_occurrences_tmp`.\n",
+    "    - (4) esse novo arquivo passará a ser o índice. Exclua o indices antigo e limpe a lista de ocorrências `lst_occurrences_tmp`.\n",
     "- O método `finish_indexing` é o método que será chamado ao finalizar a indexação. Neste contexto ele será usado para organizar o `dic_index` atualizando os atributos `term_file_start_pos` e `doc_count_with_term` para os valores corretos.\n",
     "\n",
     "Na primeira execução, não haverá arquivo e você adicionará a lista toda no arquivo de forma sequencial. Fazendo esse procedimento, você sempre irá garantir um arquivo ordenado da forma esperada."
@@ -347,7 +347,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Atividade 5(a) - método de escrita no arquivo:** Iremos necessitar, em algum momento, a escrita de uma instancia de `TermOccurrence` em arquivo. Assim deveremos implementar o método de escrita em arquivo nessa classe. Para economizar espaço e por simplicidade, será escrito em um arquivo binário armazenando os três atributos inteiros. Cada inteiro será armazenado em 4 bytes - será o suficiente para a nossa indexação. Veja um exemplo abaixo de escrita, leitura e impressão do posicionamento no arquivo (esses métodos serão uteis nessa e nas próximas atividades)."
+    "**Atividade 5(a) — método de escrita no arquivo:** Iremos necessitar, em algum momento, a escrita de uma instância de `TermOccurrence` em arquivo. Assim deveremos implementar o método de escrita em arquivo nessa classe. Para economizar espaço e por simplicidade, será escrito num arquivo binário armazenando os três atributos inteiros. Cada inteiro será armazenado em 4 ‘bytes’ — será o suficiente para a nossa indexação. Veja um exemplo abaixo de escrita, leitura e impressão do posicionamento no arquivo (esses métodos serão úteis nessa e nas próximas atividades)."
    ]
   },
   {
@@ -369,9 +369,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Atividade 5(b) - métodos next_from_file e next_from_list**: Antes de fazer a ordenação, é interessante implementar esses dois métodos que irão auxiliar na obtenção do menor elemento no arquivo e na lista, respectivamente. Considerando que a lista e o arquivo estão ordenados de forma crescente, temos que obter o primeiro elemento da lista e retirá-lo (utilize o [método pop](https://docs.python.org/3.1/tutorial/datastructures.html)).  \n",
+    "**Atividade 5(b) — métodos next_from_file e next_from_list**: Antes de fazer a ordenação, é interessante implementar esses dois métodos que irão auxiliar na obtenção do menor elemento no arquivo e na lista, respetivamente. Considerando que a lista e o arquivo estão ordenados de forma crescente, temos que obter o primeiro elemento da lista e retirá-lo (utilize o [método pop](https://docs.python.org/3.1/tutorial/datastructures.html)).\n",
     "\n",
-    "Para a leitura do arquivo, iremos usar a API [pickle](https://docs.python.org/3/library/pickle.html) que facilita inserir/carregar estruturas em arquivo binário. O método `next_from_file` já possui um arquivo aberto e você deverá ler a próxima entrada por meio da função `load` da API `pickle`. Caso não exista próximo elemento, é lançado uma exceção. Em ambos os métodos, caso não exista próximo elemento, será retonado `None`. \n",
+    "Para a leitura do arquivo, iremos usar a API [pickle](https://docs.python.org/3/library/pickle.html) que facilita inserir/carregar estruturas em arquivo binário. O método `next_from_file` já possui um arquivo aberto e você deverá ler a próxima entrada por meio da função `load` da API `pickle`. Caso não exista próximo elemento, é lançado uma exceção. Em ambos os métodos, caso não exista próximo elemento, será retornado `None`.\n",
     "\n",
     "Complete a implementação substituindo os `None` quando julgar necessário."
    ]
@@ -380,12 +380,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Atividade 7 - método save_tmp_occurrences: ** Implemente o método `save_tmp_occurrences`. Esse método deverá salvar a lista `lst_occurrences_tmp` em arquivo de forma ordenada, conforme explicado anteriormente. Neste método, você não precisa preocupar com o atributo `dic_index`. Leve em consideração os seguintes atributos/métodos:\n",
+    "**Atividade 6 — método save_tmp_occurrences:** Implemente o método `save_tmp_occurrences`. Esse método deverá salvar a lista `lst_occurrences_tmp` em arquivo de forma ordenada, conforme explicado anteriormente. Neste método, você não precisa preocupar com o atributo `dic_index`. Considere os seguintes atributos/métodos:\n",
     "\n",
     "- `idx_file_counter`:  No código, você irá criar sempre novos indices, excluindo o antigo. Este atributo será útil para definirmos o nome do arquivo do índice. O novo arquivo do índice chamará `occur_index_X` em que $X$ é o número do mesmo. \n",
-    "- `str_idx_file_name`: Atributo que armazena o arquivo indice atual. A primeira vez que executarmos `save_tmp_occurrences` não haverá arquivo criado e, assim `str_idx_file_name = None`\n",
-    "- `lst_occurrences_tmp`: Lista de ocorrencias a serem armazenadas em arquivo\n",
-    "- `next_from_file` e `next_from_list`: implementados na atividade anterior, para obter o proximo item do arquivo ou da lista. Importantes para fazer a ordenação.\n",
+    "- `str_idx_file_name`: Atributo que armazena o arquivo índice atual. A primeira vez que executarmos `save_tmp_occurrences` não haverá arquivo criado e, assim `str_idx_file_name = None`\n",
+    "- `lst_occurrences_tmp`: Lista de ocorrências a serem armazenadas em arquivo\n",
+    "- `next_from_file` e `next_from_list`: implementados na atividade anterior, para obter o próximo item do arquivo ou da lista. Importantes para fazer a ordenação.\n",
     "\n"
    ]
   },
@@ -409,7 +409,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Atividade 8: método finish_indexing: ** Agora, com as ocorrências organizadas no arquivo por termo, você deverá implementar o método `finish_indexing` para atualizar o atributo `dic_index` com a posição inicial e quantidade de documentos de cada termo nas suas instancias `TermFilePosition`. Logo após, execute o teste unitário abaixo."
+    "**Atividade 7: método finish_indexing:** Agora, com as ocorrências organizadas no arquivo por termo, você deverá implementar o método `finish_indexing` para atualizar o atributo `dic_index` com a posição inicial e quantidade de documentos de cada termo nas suas instancias `TermFilePosition`. Logo após, execute o teste unitário abaixo."
    ]
   },
   {
@@ -425,10 +425,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Atividade 9 - implementação em `FileIndex` dos métodos abstratos da classe Index: ** Como vocês perceberam, `FileIndex` é subclasse de `Index`. Assim,  precisamos implementar os métodos abstratos da classe `Index`:\n",
+    "**Atividade 8 — implementação em `FileIndex` dos métodos abstratos da classe Index:** Como vocês perceberam, `FileIndex` é subclasse de `Index`. Assim,  precisamos implementar os métodos abstratos da classe `Index`:\n",
     "\n",
     "- `create_index_entry`: no `FileIndex` para criar uma nova entrada no índice, você deverá retornar uma instancia de `TermFilePosition` para este novo `term_id`. Ao criá-lo, você não precisa de definir a posição inicial do arquivo nem a quantidade de documentos. Conforme vocês implementaram nas atividades anteriores, isso é feito apenas no momento de finalização da indexação;\n",
-    "- `add_index_occur`: Neste caso, você deverá criar e adicionar uma nova ocorrencia na lista de ocorrencias temporárias `lst_occurrences_tmp` e, caso senha passado o limite `FileIndex.TMP_OCCURRENCES_LIMIT` do número máximo de ocorrencias na lista, chamar o método `save_tmp_occurrence`.\n",
+    "- `add_index_occur`: Neste caso, você deverá criar e adicionar uma nova ocorrência na lista de ocorrencias temporárias `lst_occurrences_tmp` e, caso senha passado o limite `FileIndex.TMP_OCCURRENCES_LIMIT` do número máximo de ocorrencias na lista, chamar o método `save_tmp_occurrence`.\n",
     "- `get_occurrence_list` e `document_count_with_term`: Possuem as mesmas funcionalidades descritas na atividade 3, porém, agora você deverá considerar a estrutura criada no `FileIndex`. Lembrem-se que esse método é só chamado após a finalização da indexação, assim, considere que o índice já está pronto."
    ]
   },
@@ -436,7 +436,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Atividade 10 - Teste unitário** Dessa vez, você deverá alterar uma classe de teste unitário para conseguir executá-la. \n",
+    "**Atividade 9 — Teste unitário:** Dessa vez, você deverá alterar uma classe de teste unitário para conseguir executá-la.\n",
     "\n",
     "Agora iremos testar os métodos get_occurrence_list e document_count_with_term. Lembre-se que já temos um teste unitário para isso, porém ele testa a estrutura de um `HashIndex`. Neste caso, iremos apenas mudar a estrutura, mas os métodos serão o mesmo, por isso, conseguiremos reaproveitar o teste feito anteriormente criando apenas uma nova classe de teste. \n",
     "\n",
@@ -465,7 +465,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "De forma similar, também criamos um teste de performance. Verifique a performance da indexação em arquivo e em memória ao indexar milhões de ocorrencias de termos utilizando os testes abaixo. Note que, desta vez, estamso chamando os testes por meio de comandos Python e não pelo terminal. Assim, caso queira fazer alguma alteração no arquivos `.py`, você deve reiniciar o kernel."
+    "De forma similar, também criamos um teste de desempenho. Verifique o desempenho da indexação em arquivo e em memória ao indexar milhões de ocorrências de termos utilizando os testes abaixo. Note que, desta vez, estamos chamando os testes por comandos Python e não pelo terminal. Assim, caso queira fazer alguma alteração no arquivos `.py`, você deve reiniciar o ‘kernel’."
    ]
   },
   {
@@ -495,7 +495,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- Índice com ocorrencias em memória secundária. Veja que, abaixo, que você pode ajustar o parametro de número de ocorrências em memória. Será muito útil para não gastar tanto tempo ao indexar o conteúdo da Wikipédia. "
+    "- Índice com ocorrências em memória secundária. Veja que, abaixo, que você pode ajustar o parâmetro de número de ocorrências em memória. Será muito útil para não gastar tanto tempo ao indexar o conteúdo da Wikipédia."
    ]
   },
   {
@@ -546,14 +546,17 @@
     "from index.indexer import *\n",
     "#importamos o módulo structure\n",
     "#novamente para não precisar de executar o código do início da tarefa\n",
-    "from index.structure import *"
+    "from index.structure import *\n",
+    "#Fazemos o download do módulo nlkt para a questão 12\n",
+    "import nltk\n",
+    "nltk.download('punkt')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Atividade 11 - Limpeza dos dados com a classe Cleaner: ** A classe `Cleaner` é responsável por preprocessar o conteúdo HTML para que ele esteja preparado para indexação. Essa classe tem alguns _flags_ para definir se algum tipo de processamento opcional será feito (por exemplo, _stemming_ e remoção de _stopwords_). Para isso, você deverá implementar pequenos métodos para fazer a limpeza. Esses códigos são pequenos pois temos lindas APIs para nos ajudar 💕. Você irá fazer o processamento básico e, se quiser, pode melhorar a implementação criando exceções na remoção de acentos e não retirando maiúsculas e minúsculas de certas palavras e unindo palavras compostas, por exemplo."
+    "**Atividade 10 — Limpeza dos dados com a classe Cleaner:** A classe `Cleaner` é responsável por pré-processar o conteúdo HTML para ele estar preparado para indexação. Essa classe tem alguns _flags_ para definir se algum tipo de processamento opcional será feito (por exemplo, _stemming_ e remoção de _stopwords_). Para isso, você deverá implementar pequenos métodos para fazer a limpeza. Esses códigos são pequenos pois temos lindas APIs para nos ajudar 💕. Você irá fazer o processamento básico e, se quiser, pode melhorar a implementação criando exceções na remoção de acentos e não retirando maiúsculas e minúsculas de certas palavras e unindo palavras compostas, por exemplo."
    ]
   },
   {
@@ -562,7 +565,7 @@
    "source": [
     "Para cada tarefa, há um método para ser criado a seguir os testes iniciais serão feitos aqui no Jupyter. Não esqueça de reiniciar o kernel sempre que alterar algo no código. Logo após, haverá um [teste de integração](https://en.wikipedia.org/wiki/Integration_testing) para avaliar a indexação como um todo.\n",
     "\n",
-    "- **Transformação de HTML para texto: ** Na limpeza dos dados, iremos remover tudo que não será indexado - ou seja, o código HTML. Para isso, iremos implementar o método `html_to_plain_text` que transformará o HTML em texto corrido. Você pode utilizar o [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/) para isso e o método get_text. "
+    "- **Transformação de HTML para texto: ** Na limpeza dos dados, iremos remover tudo que não será indexado — ou seja, o código HTML. Para isso, iremos implementar o método `html_to_plain_text` que transformará o HTML em texto corrido. Você pode utilizar o [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/) para isso e o método get_text."
    ]
   },
   {
@@ -584,7 +587,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "- **Verifica se é stopword**: O método `is_stopword` retorna verdadeiro se uma palavra, passada como parâmetro, é stopword. Para isso, você irá usar o atributo `set_stop_words`. Este atibuto foi inicializado com um conjunto de stopwords de um arquivo. Esse arquivo, para testes, tem poucas stopwords. \n",
+    "- **Verifica se é stopword**: O método `is_stopword` retorna verdadeiro se uma palavra, passada como parâmetro, é stopword. Para isso, você irá usar o atributo `set_stop_words`. Este atributo foi inicializado com um conjunto de stopwords de um arquivo. Esse arquivo, para testes, tem poucas stopwords.\n",
     "    "
    ]
   },
@@ -646,16 +649,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Atividade 12 - Classe HTMLIndexer - método text_word_count: **  Você deverá implementar o método `text_word_count`, a partir de um texto. Esse método retorna um dicionário em que, para cada palavra no texto, será apresentado sua frequência. Considere que o texto já está limpo e é necessário fazer apenas o processamento das palavras.\n",
+    "**Atividade 11 — Classe HTMLIndexer — método text_word_count:** Você deverá implementar o método `text_word_count`, a partir de um texto. Esse método retorna um dicionário em que, para cada palavra no texto, será apresentado sua frequência. Considere que o texto já está limpo e é necessário fazer apenas o processamento das palavras.\n",
     "\n",
-    "Para isso, você deverá:  dividir o texto em tokens (que, no nosso caso, são as palavras e pontuações); preprocessar cada palavra usando o `HTMLIndexer.cleaner`; e, se for uma palavra válida, contabilizá-la. Para isso, será necessário [o método word_tokenize da API NLTK](https://kite.com/python/docs/nltk.word_tokenize)"
+    "Para isso, você deverá: dividir o texto em tokens (que, no nosso caso, são as palavras e pontuações); pré-processar cada palavra usando o `HTMLIndexer.cleaner`; e, se for uma palavra válida, contabilizá-la. Para isso, será necessário [o método word_tokenize da API NLTK](https://kite.com/python/docs/nltk.word_tokenize)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "{}"
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "index = HashIndex()\n",
     "indexador_teste = HTMLIndexer(index)\n",
@@ -668,7 +680,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Atividade 13 - método index_text: ** Implemente o método `index_text` que deverá (1) converter o HTML para texto simples usando `HTMLIndexer.cleaner`; (2) converter o texto em um dicionário de ocorrencias de palavras com sua frequencia (metodo da atividade 12); e (3) indexar cada palavra deste dicionário."
+    "**Atividade 12 — método index_text:** Implemente o método `index_text` que deverá (1) converter o HTML para texto simples usando `HTMLIndexer.cleaner`; (2) converter o texto em um dicionário de ocorrencias de palavras com sua frequencia (metodo da atividade 12); e (3) indexar cada palavra deste dicionário."
    ]
   },
   {
@@ -706,7 +718,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Atividade 14: Indexação de um diretorio com subdiretorios** Você deverá implementar o método `index_text_dir` que, dado um diretorio, navega em todos os seus subdiretórios e indexa todos os arquivos HTMLs. Considere que os arquivos sejam sempre nomeados pelo seu ID. Veja o exemplo em `doc_test`. Logo após, execute o teste unitário para ver a corretude do seu indexador."
+    "**Atividade 13: Indexação de um diretório com subdiretórios** Você deverá implementar o método `index_text_dir` que, dado um diretório, navega em todos os seus subdiretórios e indexa todos os arquivos HTMLs. Considere que os arquivos sejam sempre nomeados pelo seu ID. Veja o exemplo em `doc_test`. Logo após, execute o teste unitário para ver a corretude do seu indexador."
    ]
   },
   {

--- a/index/file_index_test.py
+++ b/index/file_index_test.py
@@ -4,59 +4,59 @@ from .index_structure_test import StructureTest
 from .performance_test import PerformanceTest
 
 
-
 class FileIndexTest(unittest.TestCase):
 
     def check_idx_file(self, obj_index, set_occurrences):
-        #verifica a ordem das ocorrencias
-        self.assertEqual(len( obj_index.lst_occurrences_tmp),0,"A lista de ocorrencias deve ser zerada após chamar o método save_tmp_occurrences")
-        last_occur = TermOccurrence(float('-inf'),float('-inf'),10)
+        # verifica a ordem das ocorrencias
+        self.assertEqual(len(obj_index.lst_occurrences_tmp), 0,
+                         "A lista de ocorrencias deve ser zerada após chamar o método save_tmp_occurrences")
+        last_occur = TermOccurrence(float('-inf'), float('-inf'), 10)
         set_file_occurrences = set()
-        with open(obj_index.str_idx_file_name,"rb") as idx_file:
+        with open(obj_index.str_idx_file_name, "rb") as idx_file:
             occur = obj_index.next_from_file(idx_file)
             while occur is not None:
-                self.assertTrue(occur>last_occur, msg=f"A ocorrencia {last_occur} foi colocada de forma incorreta antes da ocorrencia {occur}")
+                self.assertTrue(occur > last_occur,
+                                msg=f"A ocorrencia {last_occur} foi colocada de forma incorreta antes da ocorrencia {occur}")
                 set_file_occurrences.add(occur)
                 last_occur = occur
                 occur = obj_index.next_from_file(idx_file)
 
-        sobra_arquivo = set_file_occurrences-set_occurrences
-        sobra_lista = set_occurrences-set_file_occurrences
-        self.assertEqual(len(sobra_arquivo),0, f"Existem ocorrências no arquivo que não estavam na 'lst_occurrences_tmp': {sobra_arquivo} ")
-        self.assertEqual(len(sobra_lista),0, f"As seguintes ocorrências não foram inseridas no arquivo de indice: {sobra_lista} ")
+        sobra_arquivo = set_file_occurrences - set_occurrences
+        sobra_lista = set_occurrences - set_file_occurrences
+        self.assertEqual(len(sobra_arquivo), 0,
+                         f"Existem ocorrências no arquivo que não estavam na 'lst_occurrences_tmp': {sobra_arquivo} ")
+        self.assertEqual(len(sobra_lista), 0,
+                         f"As seguintes ocorrências não foram inseridas no arquivo de indice: {sobra_lista} ")
 
     def test_save_tmp_occurrences(self):
 
-        #testa a primeira vez (adicionando tudo na primeira vez)
+        # testa a primeira vez (adicionando tudo na primeira vez)
         self.index = FileIndex()
         set_occurrences = []
-        self.index.lst_occurrences_tmp = [TermOccurrence(2,4,5),
-                                        TermOccurrence(2,2,1),
-                                        TermOccurrence(1,2,1),
-                                        TermOccurrence(1,1,3)]
+        self.index.lst_occurrences_tmp = [TermOccurrence(2, 4, 5),
+                                          TermOccurrence(2, 2, 1),
+                                          TermOccurrence(1, 2, 1),
+                                          TermOccurrence(1, 1, 3)]
         set_occurrences = set(self.index.lst_occurrences_tmp)
         self.index.save_tmp_occurrences()
         self.check_idx_file(self.index, set_occurrences)
         print("Primeira execução (criação inicial do indice) [ok]")
 
-        #adicina alguns
-        self.index.lst_occurrences_tmp = [TermOccurrence(1,3,3),
-                                        TermOccurrence(2,3,4)]
+        # adicina alguns
+        self.index.lst_occurrences_tmp = [TermOccurrence(1, 3, 3),
+                                          TermOccurrence(2, 3, 4)]
         set_occurrences = set_occurrences | set(self.index.lst_occurrences_tmp)
         self.index.save_tmp_occurrences()
         self.check_idx_file(self.index, set_occurrences)
         print("Inserção de alguns itens - teste 1/2 [ok]")
 
+        # adiciona mais alguns
+        self.index.lst_occurrences_tmp = [TermOccurrence(2, 1, 2),
+                                          TermOccurrence(3, 2, 2),
+                                          TermOccurrence(3, 1, 1)]
 
-
-
-        #adiciona mais alguns
-        self.index.lst_occurrences_tmp = [TermOccurrence(2,1,2),
-                                        TermOccurrence(3,2,2),
-                                        TermOccurrence(3,1,1)]
-
-        #checa ordenação do arquivo e verifica todas as ocorrencias existem
-        set_occurrences = set_occurrences|set(self.index.lst_occurrences_tmp)
+        # checa ordenação do arquivo e verifica todas as ocorrencias existem
+        set_occurrences = set_occurrences | set(self.index.lst_occurrences_tmp)
         self.index.save_tmp_occurrences()
         self.check_idx_file(self.index, set_occurrences)
         print("Inserção de alguns itens - teste 2/2 [ok]")
@@ -64,53 +64,53 @@ class FileIndexTest(unittest.TestCase):
     def test_finish_indexing(self):
         self.index = FileIndex()
         self.index.lst_occurrences_tmp = [
-                                        TermOccurrence(1,1,3),
-                                        TermOccurrence(2,1,2),
-                                        TermOccurrence(3,1,1),
-                                        TermOccurrence(1,2,1),
-                                        TermOccurrence(2,2,1),
-                                        TermOccurrence(3,2,2),
-                                        TermOccurrence(1,3,3),
-                                        TermOccurrence(1,4,5),
-                                        TermOccurrence(2,4,5),
-                                        ]
-
+            TermOccurrence(1, 1, 3),
+            TermOccurrence(2, 1, 2),
+            TermOccurrence(3, 1, 1),
+            TermOccurrence(1, 2, 1),
+            TermOccurrence(2, 2, 1),
+            TermOccurrence(3, 2, 2),
+            TermOccurrence(1, 3, 3),
+            TermOccurrence(1, 4, 5),
+            TermOccurrence(2, 4, 5),
+        ]
 
         print("Lista de ocorrências a serem testadas:")
-        for i,occ in enumerate(self.index.lst_occurrences_tmp):
+        for i, occ in enumerate(self.index.lst_occurrences_tmp):
             print(f"{occ}")
         x = 100
         int_size_of_occur = None
-        with open("teste_file.idx","wb") as file:
+        with open("teste_file.idx", "wb") as file:
             self.index.lst_occurrences_tmp[0].write(file)
             int_size_of_occur = file.tell()
 
         print(f"Tamanho de cada ocorrência: {int_size_of_occur} bytes")
         self.index.save_tmp_occurrences()
-        #verifica, para cada posição
-        self.index.dic_index = {"casa":TermFilePosition(1),
-                                "verde":TermFilePosition(2),
-                                "prédio":TermFilePosition(3),
-                                "amarelo":TermFilePosition(4)}
+        # verifica, para cada posição
+        self.index.dic_index = {"casa": TermFilePosition(1),
+                                "verde": TermFilePosition(2),
+                                "prédio": TermFilePosition(3),
+                                "amarelo": TermFilePosition(4)}
         self.index.finish_indexing()
 
-        arr_termos = ["casa","verde","prédio","amarelo"]
-        #testa se o id manteve-se o mesmo
-        [self.assertEqual(self.index.dic_index[arr_termos[i]].term_id,i+1,f"O id do termo {i+1} mudou para {self.index.dic_index[arr_termos[i]].term_id}") for i in range(4)]
+        arr_termos = ["casa", "verde", "prédio", "amarelo"]
+        # testa se o id manteve-se o mesmo
+        [self.assertEqual(self.index.dic_index[arr_termos[i]].term_id, i + 1,
+                          f"O id do termo {i + 1} mudou para {self.index.dic_index[arr_termos[i]].term_id}") for i in
+         range(4)]
 
+        # testa se a quantidade de documentos que possuem um determinado termo está correto
+        arr_pos_por_termo = [0, int_size_of_occur * 3, int_size_of_occur * 6, int_size_of_occur * 7]
+        arr_pos = [1, 4, 7, 8]
+        [self.assertEqual(self.index.dic_index[arr_termos[i]].term_file_start_pos, arr_pos_por_termo[i],
+                          f"A posição inicial do termo de id {i + 1} no arquivo seria {arr_pos_por_termo[i]} (ou seja, antes da {arr_pos[i]}ª ocorrencia) e não {self.index.dic_index[arr_termos[i]].term_file_start_pos}")
+         for i in range(4)]
 
-
-        #testa se a quantidade de documentos que possuem um determinado termo está correto
-        arr_pos_por_termo = [0,int_size_of_occur*3,int_size_of_occur*6,int_size_of_occur*7]
-        arr_pos = [1,4,7,8]
-        [self.assertEqual(self.index.dic_index[arr_termos[i]].term_file_start_pos,arr_pos_por_termo[i],f"A posição inicial do termo de id {i+1} no arquivo seria {arr_pos_por_termo[i]} (ou seja, antes da {arr_pos[i]}ª ocorrencia) e não {self.index.dic_index[arr_termos[i]].term_file_start_pos}") for i in range(4)]
-
-        #testa se a quantidade de documentos que possuem um determinado termo está correto
-        arr_doc_por_termo = [3,3,1,2]
-        [self.assertEqual(self.index.dic_index[arr_termos[i]].doc_count_with_term,arr_doc_por_termo[i],f"A quantidade de documentos que possuem o termo de id {self.index.dic_index[arr_termos[i]].term_id} seria {arr_doc_por_termo[i]} e não {self.index.dic_index[arr_termos[i]].doc_count_with_term}") for i in range(4)]
-
-
-
+        # testa se a quantidade de documentos que possuem um determinado termo está correto
+        arr_doc_por_termo = [3, 3, 1, 2]
+        [self.assertEqual(self.index.dic_index[arr_termos[i]].doc_count_with_term, arr_doc_por_termo[i],
+                          f"A quantidade de documentos que possuem o termo de id {self.index.dic_index[arr_termos[i]].term_id} seria {arr_doc_por_termo[i]} e não {self.index.dic_index[arr_termos[i]].doc_count_with_term}")
+         for i in range(4)]
 
 
 if __name__ == "__main__":

--- a/index/index_structure_test.py
+++ b/index/index_structure_test.py
@@ -2,20 +2,21 @@ from index.structure import *
 
 import unittest
 
+
 class StructureTest(unittest.TestCase):
     def create_terms(self):
-        #casa apareceu 10 vezes no doc. 1
-        self.index.index("casa",1,10)
-        #vermelho apareceu 3 vezes no doc. 1
-        self.index.index("vermelho",1,3)
-        #verde apareceu 1 vez no doc. 1
-        self.index.index("verde",1,1)
-        #vermelho apareceu 1 vez no doc. 2
-        self.index.index("vermelho",2,1)
-        #vermelho apareceu 1 vez no doc. 3
-        self.index.index("vermelho",3,1)
-        #casa apareceu 3 vezes no doc. 2
-        self.index.index("casa",2,3)
+        # casa apareceu 10 vezes no doc. 1
+        self.index.index("casa", 1, 10)
+        # vermelho apareceu 3 vezes no doc. 1
+        self.index.index("vermelho", 1, 3)
+        # verde apareceu 1 vez no doc. 1
+        self.index.index("verde", 1, 1)
+        # vermelho apareceu 1 vez no doc. 2
+        self.index.index("vermelho", 2, 1)
+        # vermelho apareceu 1 vez no doc. 3
+        self.index.index("vermelho", 3, 1)
+        # casa apareceu 3 vezes no doc. 2
+        self.index.index("casa", 2, 3)
 
         self.index.finish_indexing()
 
@@ -27,25 +28,26 @@ class StructureTest(unittest.TestCase):
         self.create_terms()
 
     def test_document_count(self):
-        self.assertEqual(3,self.index.document_count)
+        self.assertEqual(3, self.index.document_count)
 
     def test_vocabulary(self):
-        set_expected_vocab = {"casa","vermelho","verde"}
+        set_expected_vocab = {"casa", "vermelho", "verde"}
         set_vocab = self.index.vocabulary
 
-        self.assertCountEqual(set_expected_vocab,set_vocab,f"Deveria haver a seguinte lista/conjunto: {set_expected_vocab} mas foi retornado: {set_vocab}")
+        self.assertCountEqual(set_expected_vocab, set_vocab,
+                              f"Deveria haver a seguinte lista/conjunto: {set_expected_vocab} mas foi retornado: {set_vocab}")
 
     def test_document_count_with_term(self):
-        self.assertEqual(2,self.index.document_count_with_term("casa"), f"Casa apareceu em dois documentos")
-        self.assertEqual(3,self.index.document_count_with_term("vermelho"), f"Vemelho apareceu em dois documentos")
-        self.assertEqual(1,self.index.document_count_with_term("verde"), f"Verde apareceu em dois documentos")
-        self.assertEqual(0,self.index.document_count_with_term("cinza"), f"Cinza não está indexado, deveria retornar zero")
-
+        self.assertEqual(2, self.index.document_count_with_term("casa"), f"Casa apareceu em dois documentos")
+        self.assertEqual(3, self.index.document_count_with_term("vermelho"), f"Vemelho apareceu em dois documentos")
+        self.assertEqual(1, self.index.document_count_with_term("verde"), f"Verde apareceu em dois documentos")
+        self.assertEqual(0, self.index.document_count_with_term("cinza"),
+                         f"Cinza não está indexado, deveria retornar zero")
 
     def test_get_occurrence_list(self):
-        dict_expected_index = {"casa":{1:10, 2:3},
-                                "verde":{1:1},
-                                "vermelho":{1:3,2:1,3:1}}
+        dict_expected_index = {"casa": {1: 10, 2: 3},
+                               "verde": {1: 1},
+                               "vermelho": {1: 3, 2: 1, 3: 1}}
 
         for term, dic_doc_freq in dict_expected_index.items():
             list_occur = self.index.get_occurrence_list(term)
@@ -53,15 +55,19 @@ class StructureTest(unittest.TestCase):
                 doc_id = occur.doc_id
                 frequency = occur.term_freq
                 self.assertTrue(doc_id in dict_expected_index[term], f"O termo {term} não ocorre no documento {doc_id}")
-                self.assertEqual(dict_expected_index[term][doc_id],frequency, f"Erro o termo {term} deveria ocorrer {dict_expected_index[term][doc_id]}x no documento {doc_id} e não {frequency}")
-            self.assertEqual( len(dic_doc_freq.keys()), len(list_occur), f"A lista de occorencia tem ocorrencias a mais (ou a menos) do termo {term}" )
+                self.assertEqual(dict_expected_index[term][doc_id], frequency,
+                                 f"Erro o termo {term} deveria ocorrer {dict_expected_index[term][doc_id]}x no documento {doc_id} e não {frequency}")
+            self.assertEqual(len(dic_doc_freq.keys()), len(list_occur),
+                             f"A lista de occorencia tem ocorrencias a mais (ou a menos) do termo {term}")
 
         list_occur = self.index.get_occurrence_list('xuxu')
-        self.assertListEqual(list_occur,[],"O termo xuxu não existe, deveria retornar lista vazia")
+        self.assertListEqual(list_occur, [], "O termo xuxu não existe, deveria retornar lista vazia")
+
 
 class FileStructureTest(StructureTest):
     def setUp(self):
         None
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/index/indexer.py
+++ b/index/indexer.py
@@ -6,67 +6,66 @@ import os
 
 
 class Cleaner:
-    def __init__(self,stop_words_file:str,language:str,
-                        perform_stop_words_removal:bool,perform_accents_removal:bool,
-                        perform_stemming:bool):
+    def __init__(self, stop_words_file: str, language: str,
+                 perform_stop_words_removal: bool, perform_accents_removal: bool,
+                 perform_stemming: bool):
         self.set_stop_words = self.read_stop_words(stop_words_file)
 
         self.stemmer = SnowballStemmer(language)
-        in_table =  "áéíóúâêôçãẽõü"
+        in_table = "áéíóúâêôçãẽõü"
         out_table = "aeiouaeocaeou"
-        #altere a linha abaixo para remoção de acentos (Atividade 11)
+        # altere a linha abaixo para remoção de acentos (Atividade 11)
         self.accents_translation_table = None
         self.set_punctuation = set(string.punctuation)
 
-        #flags
+        # flags
         self.perform_stop_words_removal = perform_stop_words_removal
         self.perform_accents_removal = perform_accents_removal
         self.perform_stemming = perform_stemming
 
-    def html_to_plain_text(self,html_doc:str) ->str:
+    def html_to_plain_text(self, html_doc: str) -> str:
         return None
 
-    def read_stop_words(self,str_file):
+    @staticmethod
+    def read_stop_words(str_file) -> set:
         set_stop_words = set()
-        with open(str_file, "r") as stop_words_file:
+        with open(str_file, encoding='utf-8') as stop_words_file:
             for line in stop_words_file:
                 arr_words = line.split(",")
                 [set_stop_words.add(word) for word in arr_words]
         return set_stop_words
-    def is_stop_word(self,term:str):
+
+    def is_stop_word(self, term: str):
         return True
 
-    def word_stem(self,term:str):
+    def word_stem(self, term: str):
         return ""
 
-
-    def remove_accents(self,term:str) ->str:
+    def remove_accents(self, term: str) -> str:
         return None
 
-
-    def preprocess_word(self,term:str) -> str:
-
+    def preprocess_word(self, term: str) -> str or None:
         return None
-
 
 
 class HTMLIndexer:
     cleaner = Cleaner(stop_words_file="stopwords.txt",
-                        language="portuguese",
-                        perform_stop_words_removal=True,
-                        perform_accents_removal=True,
-                        perform_stemming=True)
-    def __init__(self,index):
+                      language="portuguese",
+                      perform_stop_words_removal=True,
+                      perform_accents_removal=True,
+                      perform_stemming=True)
+
+    def __init__(self, index):
         self.index = index
 
-    def text_word_count(self,plain_text:str):
+    def text_word_count(self, plain_text: str):
         dic_word_count = {}
 
         return dic_word_count
-    def index_text(self,doc_id:int, text_html:str):
+
+    def index_text(self, doc_id: int, text_html: str):
         pass
 
-    def index_text_dir(self,path:str):
-
+    def index_text_dir(self, path: str):
         for str_sub_dir in os.listdir(path):
             path_sub_dir = f"{path}/{str_sub_dir}"

--- a/index/indexer_test.py
+++ b/index/indexer_test.py
@@ -2,6 +2,7 @@ from index.indexer import *
 from index.structure import *
 import unittest
 
+
 class IndexerTest(unittest.TestCase):
     def test_indexer(self):
         obj_index = HashIndex()
@@ -10,17 +11,21 @@ class IndexerTest(unittest.TestCase):
         set_vocab = set(obj_index.vocabulary)
         set_expected_vocab = set(['a', 'cas', 'ser', 'verd', 'ou', 'nao', 'eis', 'questa'])
 
-        sobra_expected = set_expected_vocab-set_vocab
-        sobra_vocab = set_vocab-set_expected_vocab
+        sobra_expected = set_expected_vocab - set_vocab
+        sobra_vocab = set_vocab - set_expected_vocab
 
-        self.assertTrue(len(sobra_expected) == 0 and len(sobra_vocab)==0, f"O Vocabulário indexado não é o esperado!\nVocabulario indexado: {set_vocab}\nVocabulário esperado: {set_expected_vocab}")
+        self.assertTrue(len(sobra_expected) == 0 and len(sobra_vocab) == 0,
+                        f"O Vocabulário indexado não é o esperado!\nVocabulario indexado: {set_vocab}\nVocabulário esperado: {set_expected_vocab}")
         lst_occur = obj_index.get_occurrence_list("cas")
-        dic_expected = {111:TermOccurrence(111,2,1),
-                        100102:TermOccurrence(100102,2,2)}
+        dic_expected = {111: TermOccurrence(111, 2, 1),
+                        100102: TermOccurrence(100102, 2, 2)}
         for occur in lst_occur:
-                self.assertTrue(type(occur.doc_id) == int,f"O tipo do documento deveria ser inteiro")
-                self.assertTrue(occur.doc_id in dic_expected,f"O docid número {occur.doc_id} não deveria existir ou não deveria indexar o termo 'cas'")
-                self.assertEqual(dic_expected[occur.doc_id].term_freq,occur.term_freq, f"A frequencia do termo 'cas' no documento {occur.doc_id} deveria ser {occur.term_freq}")
+            self.assertTrue(type(occur.doc_id) == int, f"O tipo do documento deveria ser inteiro")
+            self.assertTrue(occur.doc_id in dic_expected,
+                            f"O docid número {occur.doc_id} não deveria existir ou não deveria indexar o termo 'cas'")
+            self.assertEqual(dic_expected[occur.doc_id].term_freq, occur.term_freq,
+                             f"A frequencia do termo 'cas' no documento {occur.doc_id} deveria ser {occur.term_freq}")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/index/performance_test.py
+++ b/index/performance_test.py
@@ -5,11 +5,7 @@ from datetime import datetime
 import math
 import tracemalloc
 import unittest
-from random import randrange,seed
-
-
-
-
+from random import randrange, seed
 
 
 class PerformanceTest(unittest.TestCase):
@@ -21,20 +17,20 @@ class PerformanceTest(unittest.TestCase):
 
     def create_vocabulary(self):
         vocabulary = []
-        for i in range(65,91):
-            for j in range(65,91):
-                for k in range(65,91):
+        for i in range(65, 91):
+            for j in range(65, 91):
+                for k in range(65, 91):
                     vocabulary.append(f"{chr(i)}{chr(j)}{chr(k)}")
         return vocabulary
 
-    def print_status(self,count:int,total:int):
+    def print_status(self, count: int, total: int):
 
-        delta = datetime.now()-self.time
-        porc_complete = math.floor(count/total*100)
+        delta = datetime.now() - self.time
+        porc_complete = math.floor(count / total * 100)
         current, peak = tracemalloc.get_traced_memory()
 
         clear_output(wait=True)
-        print(f"Memoria usada: {current / 10**6:,} MB; Máximo {peak / 10**6:,} MB")
+        print(f"Memoria usada: {current / 10 ** 6:,} MB; Máximo {peak / 10 ** 6:,} MB")
         print(f"Indexando ocorrencia #{count:,}/{total:,} ({porc_complete}%)")
         print(f"Tempo gasto: {delta.total_seconds()}s")
 
@@ -44,18 +40,17 @@ class PerformanceTest(unittest.TestCase):
         words = []
         for doc_i in range(PerformanceTest.NUM_DOCS):
             for term_j in range(PerformanceTest.NUM_TERM_PER_DOC):
-                idx_term = randrange(0,len(self.vocabulary))
+                idx_term = randrange(0, len(self.vocabulary))
                 str_term = self.vocabulary[idx_term]
-                self.index.index(str_term, doc_i, (count%10)+1)
-                #indiceTeste.index(vocabulario[(count+1)%15625], d, (count%10)+1);
-                if count%50000==0:
-                    self.print_status(count,PerformanceTest.NUM_DOCS*PerformanceTest.NUM_TERM_PER_DOC)
+                self.index.index(str_term, doc_i, (count % 10) + 1)
+                # indiceTeste.index(vocabulario[(count+1)%15625], d, (count%10)+1);
+                if count % 50000 == 0:
+                    self.print_status(count, PerformanceTest.NUM_DOCS * PerformanceTest.NUM_TERM_PER_DOC)
 
-                count+=1
+                count += 1
         return count
 
     def test_performance(self):
-
 
         print("Criando vocabulário...")
         self.vocabulary = self.create_vocabulary()
@@ -63,19 +58,24 @@ class PerformanceTest(unittest.TestCase):
         tracemalloc.start()
         self.time = datetime.now()
         total = self.index_words()
-        self.print_status(total,total)
+        self.print_status(total, total)
         tracemalloc.stop()
 
+
 import time
+
+
 class FilePerformanceTest(PerformanceTest):
     def setUp(self):
         self.index = FileIndex()
+
 
 def test():
     for i in range(10):
         clear_output(wait=True)
         print(f"oi {i}")
         time.sleep(1)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/index/structure.py
+++ b/index/structure.py
@@ -7,12 +7,13 @@ import os
 import pickle
 import gc
 
+
 class Index:
     def __init__(self):
         self.dic_index = {}
         self.set_documents = set()
 
-    def index(self, term:str, doc_id:int, term_freq:int):
+    def index(self, term: str, doc_id: int, term_freq: int):
         if term not in self.dic_index:
             int_term_id = None
             self.dic_index[term] = self.create_index_entry(int_term_id)
@@ -20,7 +21,6 @@ class Index:
             int_term_id = None
 
         self.add_index_occur(self.dic_index[term], doc_id, int_term_id, term_freq)
-
 
     @property
     def vocabulary(self) -> List:
@@ -31,25 +31,24 @@ class Index:
         return 0
 
     @abstractmethod
-    def get_term_id(self, term:str):
-        raise NotImplementedError("Voce deve criar uma subclasse e a mesma deve sobrepor este método")
-
-
-    @abstractmethod
-    def create_index_entry(self, termo_id:int):
+    def get_term_id(self, term: str):
         raise NotImplementedError("Voce deve criar uma subclasse e a mesma deve sobrepor este método")
 
     @abstractmethod
-    def add_index_occur(self, entry_dic_index, doc_id:int, term_id:int, freq_termo:int):
+    def create_index_entry(self, termo_id: int):
         raise NotImplementedError("Voce deve criar uma subclasse e a mesma deve sobrepor este método")
 
     @abstractmethod
-    def get_occurrence_list(self, term:str) -> List:
+    def add_index_occur(self, entry_dic_index, doc_id: int, term_id: int, freq_termo: int):
         raise NotImplementedError("Voce deve criar uma subclasse e a mesma deve sobrepor este método")
 
     @abstractmethod
-    def document_count_with_term(self,term:str) -> int:
-         raise NotImplementedError("Voce deve criar uma subclasse e a mesma deve sobrepor este método")
+    def get_occurrence_list(self, term: str) -> List:
+        raise NotImplementedError("Voce deve criar uma subclasse e a mesma deve sobrepor este método")
+
+    @abstractmethod
+    def document_count_with_term(self, term: str) -> int:
+        raise NotImplementedError("Voce deve criar uma subclasse e a mesma deve sobrepor este método")
 
     def finish_indexing(self):
         pass
@@ -64,9 +63,10 @@ class Index:
     def __repr__(self):
         return str(self)
 
+
 @total_ordering
 class TermOccurrence:
-    def __init__(self,doc_id:int,term_id:int, term_freq:int):
+    def __init__(self, doc_id: int, term_id: int, term_freq: int):
         self.doc_id = doc_id
         self.term_id = term_id
         self.term_freq = term_freq
@@ -75,11 +75,12 @@ class TermOccurrence:
         pass
 
     def __hash__(self):
-    	return hash((self.doc_id,self.term_id))
-    def __eq__(self,other_occurrence:"TermOccurrence"):
+        return hash((self.doc_id, self.term_id))
+
+    def __eq__(self, other_occurrence: "TermOccurrence"):
         return False
 
-    def __lt__(self,other_occurrence:"TermOccurrence"):
+    def __lt__(self, other_occurrence: "TermOccurrence"):
         return False
 
     def __str__(self):
@@ -89,42 +90,40 @@ class TermOccurrence:
         return str(self)
 
 
-#HashIndex é subclasse de Index
+# HashIndex é subclasse de Index
 class HashIndex(Index):
-    def get_term_id(self, term:str):
+    def get_term_id(self, term: str):
         return self.dic_index[term][0].term_id
 
-    def create_index_entry(self, termo_id:int) -> List:
+    def create_index_entry(self, termo_id: int) -> List:
         return None
 
-    def add_index_occur(self, entry_dic_index:List[TermOccurrence], doc_id:int, term_id:int, term_freq:int):
+    def add_index_occur(self, entry_dic_index: List[TermOccurrence], doc_id: int, term_id: int, term_freq: int):
         entry_dic_index.append(None)
 
-    def get_occurrence_list(self,term: str)->List:
+    def get_occurrence_list(self, term: str) -> List:
         return []
 
-    def document_count_with_term(self,term:str) -> int:
+    def document_count_with_term(self, term: str) -> int:
         return 0
 
 
-
-
-
 class TermFilePosition:
-    def __init__(self,term_id:int,  term_file_start_pos:int=None, doc_count_with_term:int = None):
+    def __init__(self, term_id: int, term_file_start_pos: int = None, doc_count_with_term: int = None):
         self.term_id = term_id
 
-        #a serem definidos após a indexação
+        # a serem definidos após a indexação
         self.term_file_start_pos = term_file_start_pos
         self.doc_count_with_term = doc_count_with_term
 
     def __str__(self):
         return f"term_id: {self.term_id}, doc_count_with_term: {self.doc_count_with_term}, term_file_start_pos: {self.term_file_start_pos}"
+
     def __repr__(self):
         return str(self)
 
-class FileIndex(Index):
 
+class FileIndex(Index):
     TMP_OCCURRENCES_LIMIT = 1000000
 
     def __init__(self):
@@ -134,14 +133,14 @@ class FileIndex(Index):
         self.idx_file_counter = 0
         self.str_idx_file_name = "occur_idx_file"
 
-    def get_term_id(self, term:str):
+    def get_term_id(self, term: str):
         return self.dic_index[term].term_id
 
-    def create_index_entry(self, term_id:int) -> TermFilePosition:
-        return  TermFilePosition(term_id)
+    def create_index_entry(self, term_id: int) -> TermFilePosition:
+        return TermFilePosition(term_id)
 
-    def add_index_occur(self, entry_dic_index:TermFilePosition,  doc_id:int, term_id:int, term_freq:int):
-        self.lst_occurrences_tmp.append(TermOccurrence(doc_id,term_id,term_freq))
+    def add_index_occur(self, entry_dic_index: TermFilePosition, doc_id: int, term_id: int, term_freq: int):
+        self.lst_occurrences_tmp.append(TermOccurrence(doc_id, term_id, term_freq))
 
         if len(self.lst_occurrences_tmp) >= FileIndex.TMP_OCCURRENCES_LIMIT:
             self.save_tmp_occurrences()
@@ -149,29 +148,23 @@ class FileIndex(Index):
     def next_from_list(self) -> TermOccurrence:
         return None
 
-    def next_from_file(self,file_idx) -> TermOccurrence:
-            #next_from_file = pickle.load(file_idx)
+    def next_from_file(self, file_idx) -> TermOccurrence:
+        # next_from_file = pickle.load(file_idx)
         bytes_doc_id = file_idx.read(4)
         if not bytes_doc_id:
             return None
-        #seu código aqui :)
+            # seu código aqui :)
 
         return TermOccurrence(doc_id, term_id, term_freq)
 
-
     def save_tmp_occurrences(self):
 
-        #ordena pelo term_id, doc_id
-        #Para eficiencia, todo o codigo deve ser feito com o garbage
-        #collector desabilitado
-        gc.disable()
-        
-        #ordena pelo term_id, doc_id
-        
-        
-        ### Abra um arquivo novo faça a ordenação externa: compar sempre a primeira posição
-        ### da lista com a primeira possição do arquivo usando os métodos next_from_list e next_from_file
-        ### para armazenar no novo indice ordenado
+        # Ordena pelo term_id, doc_id
+        #    Para eficiência, todo o código deve ser feito com o garbage collector desabilitado gc.disable()
+
+        """Abra um arquivo novo faça a ordenação externa: comparar sempre a primeira posição
+        da lista com a primeira posição do arquivo usando os métodos next_from_list e next_from_file
+        para armazenar no novo índice ordenado"""
 
         gc.enable()
 
@@ -179,18 +172,19 @@ class FileIndex(Index):
         if len(self.lst_occurrences_tmp) > 0:
             self.save_tmp_occurrences()
 
-        #Sugestão: faça a navegação e obetenha um mapeamento 
+        # Sugestão: faça a navegação e obetenha um mapeamento
         # id_termo -> obj_termo armazene-o em dic_ids_por_termo
         dic_ids_por_termo = {}
-        for str_term,obj_term in self.dic_index.items():
-            pass
-        
-        with open(self.str_idx_file_name,'rb') as idx_file:
-            #navega nas ocorrencias para atualizar cada termo em dic_ids_por_termo 
-            #apropriadamente
+        for str_term, obj_term in self.dic_index.items():
             pass
 
-    def get_occurrence_list(self,term: str)->List:
+        with open(self.str_idx_file_name, 'rb') as idx_file:
+            # navega nas ocorrencias para atualizar cada termo em dic_ids_por_termo
+            # apropriadamente
+            pass
+
+    def get_occurrence_list(self, term: str) -> List:
         return []
-    def document_count_with_term(self,term:str) -> int:
+
+    def document_count_with_term(self, term: str) -> int:
         return 0


### PR DESCRIPTION
- Adição da pasta .idea (pasta de configurações de IDE do pycharm) no gitignore;
-  Remoção do arquivo `index/__init__.py`;
-  Formatação de código de acordo com a [PEP 8](https://www.python.org/dev/peps/pep-0008/);
- Adição do trecho de código
```.py
import nltk
nltk.download('punkt')
```
junto aos imports anteriories à questão 11 fazendo com que parasse de ocorrer o problema do nltk não sendo importado na questão 12;
-  Reformulação do método `read_stop_words` da classe `Cleaner`:
    - adição do tipo de retorno (no caso set)
    - encoding tratando *utf-8* (o teste da verificação de stop-word nunca passava já que a palavra 'é' não era corretamente interpretada na leitura do arquivo)
    - método estático (não depende de self, por tanto pode ser um `staticmethod` ou um `classmethod`)
- Ordem das questões: antes pulava da 5b para a 7, fiz a 7 virar 6, a 8 vira 7 e assim por diante;
- Markdown não negritando questões. Algumas questões do arquivo jupyter não estavam com o título negritado.
- Erros de português corrigidos (alguns não são necessariamente erros):
    - Caractere de menos estava erroneamente no lugar do caractere travessão;
    - Acentuações em geral;
    - Erros de concordância verbal em geral;
    - Performance é um estrangeirismo. É preferível dizer desempenho ou atuação.
        - Exemplo:
            - "Incorreto": curriculum vitae
            - "Correto": currículo
    
 