### PR TITLE
add index.structure import

### DIFF
--- a/TP2 - Dojo - Indice.ipynb
+++ b/TP2 - Dojo - Indice.ipynb
@@ -133,6 +133,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from index.structure import *\n",
     "index = HashIndex()\n",
     "#indexação do documento 1\n",
     "index.index(\"a\",1,1)\n",


### PR DESCRIPTION
Adicionando import para facilitar a execução caso o aluno queira rodar apenas esta célula do Jupyter. 